### PR TITLE
Ensure scikit-learn nodes argument match with attributes & Add factory for STCM model with test

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ preprocessing = PreprocessingFactory.factory_pipeline(
 )
 
 fragmentation = VelocityFragmentationFactory.factory_pipeline(max_velocity_hard_limit=4)
-clustering = FDBSCANFactory.factory_pipeline(eps=30, min_samples=3)
+clustering = FDBSCANFactory.factory_pipeline(
+    source_vehicle_id_column="plate_no",
+    eps=30,
+    min_samples=3,
+)
 
 activity_extraction = ActivityExtractionSession(
     preprocessing=preprocessing,
@@ -65,7 +69,6 @@ activity_extraction.predict(gps)
 ## Linker module implementation 🔵 🟣 ⚫️
 
 **[Overview linker module components](https://github.com/WasteLabs/gps_activity/tree/main/docs/linker/README.md)**
-
 
 ```python
 # Initilize linkage components

--- a/gps_activity/extraction/factory/clustering/__init__.py
+++ b/gps_activity/extraction/factory/clustering/__init__.py
@@ -1,5 +1,8 @@
 from .fdbscan import FDBSCANFactory
+from .stcm import STCMFactory
+
 
 __all__ = [
     "FDBSCANFactory",
+    "STCMFactory",
 ]

--- a/gps_activity/extraction/factory/clustering/fdbscan.py
+++ b/gps_activity/extraction/factory/clustering/fdbscan.py
@@ -25,7 +25,11 @@ class FDBSCANFactory(AbstractPipelineFactory):
         n_jobs=-1,
     ) -> Pipeline:
         """
-        Function builds scikit-learn pipeline and accepts DBSCAN hyper parameters
+        Function builds scikit-learn clustering pipeline
+        with fragmented density-based spatial clustering model.
+
+        Built-in constraints:
+        - Only one vehicle per pipeline run
 
         Args:
         eps: max distance to link a points to cluster

--- a/gps_activity/extraction/factory/clustering/stcm.py
+++ b/gps_activity/extraction/factory/clustering/stcm.py
@@ -1,0 +1,57 @@
+from typing import Dict, List, Union
+
+from sklearn.pipeline import Pipeline
+
+
+from ... import nodes as local_nodes
+from .... import nodes as global_nodes
+from ....abstract import AbstractPipelineFactory
+from ....models import DataFramePivotFields
+
+
+class STCMFactory(AbstractPipelineFactory):
+
+    # flake8: noqa: CFQ002
+    @staticmethod
+    def factory_pipeline(
+        source_vehicle_id_column: str,
+        eps: float = 20,
+        min_duration_sec: Union[int, float] = 60,
+    ) -> Pipeline:
+        """
+        Function builds scikit-learn clustering pipeline
+        with Spatio-temporal clustering model.
+
+        Built-in constraints:
+        - Only one vehicle per pipeline run
+
+        Returns:
+        sklear.pipeline.Pipeline: Scikit-learn clustering pipeline
+        """
+        pivot_fields = DataFramePivotFields(source_vehicle_id=source_vehicle_id_column)
+        return Pipeline(
+            [
+                (
+                    "unique_vehicle_constrain",
+                    global_nodes.UniqueVehicleConstrain(pivot_fields=pivot_fields),
+                ),
+                (
+                    "select_columns",
+                    global_nodes.SelectColumns(
+                        columns=[
+                            pivot_fields.projected_lat,
+                            pivot_fields.projected_lon,
+                            pivot_fields.computed_unixtime,
+                            pivot_fields.fragmentation_output,
+                        ],
+                    ),
+                ),
+                (
+                    "clustering_stcm",
+                    local_nodes.STCM(
+                        eps=eps,
+                        min_duration_sec=min_duration_sec,
+                    ),
+                ),
+            ],
+        )

--- a/gps_activity/extraction/nodes/fdbscan.py
+++ b/gps_activity/extraction/nodes/fdbscan.py
@@ -33,6 +33,14 @@ class FDBSCAN(AbstractPredictor):
         n_jobs=-1,
     ):
         self.clustering_candidate_col = clustering_candidate_col
+        self.eps = eps
+        self.min_samples = min_samples
+        self.metric = metric
+        self.metric_params = metric_params
+        self.algorithm = algorithm
+        self.leaf_size = leaf_size
+        self.p = p
+        self.n_jobs = n_jobs
         self.__dbscan = DBSCAN(
             eps=eps,
             min_samples=min_samples,

--- a/gps_activity/extraction/nodes/stcm.py
+++ b/gps_activity/extraction/nodes/stcm.py
@@ -41,6 +41,12 @@ class STCM(AbstractPredictor):
         eps: float,
         min_duration_sec: float,
     ):
+        """
+        Args:
+        eps (float): Max distance span between 2 adjacent
+            gps records to link together
+        min_duration_sec (float): Minimum duration spent on site to form cluster
+        """
         self.eps = eps
         self.min_duration_sec = min_duration_sec
 

--- a/gps_activity/nodes/schema_validator.py
+++ b/gps_activity/nodes/schema_validator.py
@@ -9,10 +9,10 @@ class PanderaValidator(AbstractNode):
     """
 
     def __init__(self, pivot_fields: DataFramePivotFields):
-        self.pandera_schema = pivot_fields.pandera_schema
+        self.pivot_fields = pivot_fields.pandera_schema
 
     def fit(self, X: pd.DataFrame, y=None):
         return self
 
     def transform(self, X: pd.DataFrame) -> pd.DataFrame:
-        return self.pandera_schema.validate(X)
+        return self.pivot_fields.validate(X)

--- a/tests/extraction/clustering/conftest.py
+++ b/tests/extraction/clustering/conftest.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 
 from gps_activity.extraction.factory.clustering import FDBSCANFactory
+from gps_activity.extraction.factory.clustering import STCMFactory
 from gps_activity.models import DataFramePivotFields
 from gps_activity.models import DefaultValues
 
@@ -30,6 +31,11 @@ def clustering_gps_points():
 
 
 @pytest.fixture
+def expected_cluster_count() -> int:
+    return 3
+
+
+@pytest.fixture
 def many_vehicle_gps(clustering_gps_points: pd.DataFrame):
     df = clustering_gps_points
     plate_no = df[pivot_fields.source_vehicle_id].to_list()
@@ -45,3 +51,51 @@ def fdbscan_pipeline(gps_pivot_fields: DataFramePivotFields):
         eps=2,
         min_samples=3,
     )
+
+
+@pytest.fixture
+def stcm_pipeline(gps_pivot_fields: DataFramePivotFields):
+    return STCMFactory.factory_pipeline(
+        source_vehicle_id_column=gps_pivot_fields.source_vehicle_id,
+        eps=1,
+        min_duration_sec=2,
+    )
+
+
+@pytest.fixture
+def clustering_output_column(gps_pivot_fields: DataFramePivotFields):
+    return DataFramePivotFields().clustering_output
+
+
+@pytest.fixture
+def noise_impute_value(gps_pivot_fields: DataFramePivotFields):
+    return DefaultValues().noise_gps_cluster_id
+
+
+@pytest.fixture
+def sctm_test_candidate() -> pd.DataFrame:
+    """
+    corner case with skip point at the middle
+    """
+    return pd.DataFrame(
+        {
+            pivot_fields.projected_lat: [0, 0, 0, 4, 5, 5, 5],
+            pivot_fields.projected_lon: [0, 1, 2, 6, 8, 9, 10],
+            pivot_fields.computed_unixtime: [0, 1, 2, 4, 5, 6, 7],
+            pivot_fields.clustering_output: [0] * 3 + [-1] + [1] * 3,
+            pivot_fields.fragmentation_output: [True] * 7,
+            pivot_fields.source_vehicle_id: ["123"] * 7,
+            "dummy_field_1": ["123"] * 7,
+            "dummy_field_2": ["123"] * 7,
+        },
+    )
+
+
+def ensure_ignore_non_cluster_candidates(
+    gps: pd.DataFrame,
+    fragmentation_flag: str,
+    cluster_cand_col: str,
+    noise_impute_value: int,
+):
+    cluster_ids = gps.loc[~gps[fragmentation_flag], cluster_cand_col]
+    assert (cluster_ids == noise_impute_value).all()

--- a/tests/extraction/clustering/conftest.py
+++ b/tests/extraction/clustering/conftest.py
@@ -1,0 +1,47 @@
+import pandas as pd
+import pytest
+
+from gps_activity.extraction.factory.clustering import FDBSCANFactory
+from gps_activity.models import DataFramePivotFields
+from gps_activity.models import DefaultValues
+
+default_values = DefaultValues()
+pivot_fields = DataFramePivotFields()
+
+
+@pytest.fixture
+def clustering_gps_points():
+    x = list(range(10)) + [40, 80, 120] + list(range(150, 160))
+    y = list(range(len(x)))
+    unixtime = list(range(len(x)))
+    cluster_candidates = [True] * 5 + [False] * 5 + [True] * 13
+    df = pd.DataFrame(
+        {
+            pivot_fields.projected_lat: x,
+            pivot_fields.projected_lon: y,
+            pivot_fields.computed_unixtime: unixtime,
+            pivot_fields.fragmentation_output: cluster_candidates,
+        },
+    )
+    df["garbage1"] = "123"
+    df["garbage2"] = "123"
+    df[pivot_fields.source_vehicle_id] = "123"
+    return df
+
+
+@pytest.fixture
+def many_vehicle_gps(clustering_gps_points: pd.DataFrame):
+    df = clustering_gps_points
+    plate_no = df[pivot_fields.source_vehicle_id].to_list()
+    plate_no[-1] = "321"
+    df[pivot_fields.source_vehicle_id] = plate_no
+    return df
+
+
+@pytest.fixture
+def fdbscan_pipeline(gps_pivot_fields: DataFramePivotFields):
+    return FDBSCANFactory.factory_pipeline(
+        source_vehicle_id_column=gps_pivot_fields.source_vehicle_id,
+        eps=2,
+        min_samples=3,
+    )

--- a/tests/extraction/clustering/test_sctm_pipeline.py
+++ b/tests/extraction/clustering/test_sctm_pipeline.py
@@ -1,0 +1,56 @@
+import logging
+import numpy as np
+import pandas as pd
+from sklearn.pipeline import Pipeline
+
+from .conftest import ensure_ignore_non_cluster_candidates
+
+
+class TestSTCM:
+    def test_instance(self, stcm_pipeline: Pipeline):
+        assert isinstance(stcm_pipeline, Pipeline)
+
+    def test_pipeline(
+        self,
+        clustering_gps_points: pd.DataFrame,
+        stcm_pipeline: Pipeline,
+        clustering_output_column: str,
+        gps_pivot_fields,
+        noise_impute_value: int,
+    ):
+        y_pred = stcm_pipeline.fit_predict(clustering_gps_points)
+        clustering_gps_points[clustering_output_column] = y_pred
+        ensure_ignore_non_cluster_candidates(
+            clustering_gps_points,
+            gps_pivot_fields.fragmentation_output,
+            clustering_output_column,
+            noise_impute_value,
+        )
+
+    def test_unique_vehicle_constrain(
+        self,
+        many_vehicle_gps: pd.DataFrame,
+        stcm_pipeline: Pipeline,
+    ):
+        try:
+            stcm_pipeline.fit_predict(many_vehicle_gps)
+            raise AssertionError("Must fail due to single vehicle constrain")
+        except ValueError:
+            assert True
+
+    def test_clustering_correctness(
+        self,
+        sctm_test_candidate: pd.DataFrame,
+        stcm_pipeline: Pipeline,
+        gps_pivot_fields,
+        round_tolerance: float,
+    ):
+        predictions = stcm_pipeline.fit_predict(sctm_test_candidate.copy())
+        logging.info(f"predictions: {predictions}")
+        logging.info(f"expected: {sctm_test_candidate[gps_pivot_fields.clustering_output]}")
+        assert np.allclose(
+            predictions,
+            sctm_test_candidate[gps_pivot_fields.clustering_output],
+            atol=round_tolerance,
+            rtol=round_tolerance,
+        )

--- a/tests/extraction/nodes/test_stcm.py
+++ b/tests/extraction/nodes/test_stcm.py
@@ -73,7 +73,6 @@ class TestSTCM:
     def test_stcm(self, stcm: STCM, gps: pd.DataFrame, round_tolerance: float):
         clusters_predicted = stcm.fit_predict(gps)
         clusters_expected = gps[pivot_fields.clustering_output].values
-        print(f"{clusters_predicted} vs {clusters_expected}")
         assert np.allclose(
             clusters_expected,
             clusters_predicted,


### PR DESCRIPTION
1. Fixed: scikit-learn nodes attribute names with constructor arguments
2. Added STCM pipeline factory function
3. Added test cases to STCM factory pipeline
4. Refactored test cases of STCM & FDBSCAN clustering pipelines